### PR TITLE
Changing logic of date field. When it's empty, change to current date.

### DIFF
--- a/src/json2mongo.ts
+++ b/src/json2mongo.ts
@@ -18,7 +18,7 @@ export const json2mongo = (obj: any) => {
         }
         return new Date(val);
       case '$decimal128':
-        return new mongo.Decimal128(Buffer  .from(val));
+        return new mongo.Decimal128(Buffer.from(val));
       case '$timestamp':
         return new mongo.Timestamp(val.t, val.i);
       case '$regex':

--- a/src/json2mongo.ts
+++ b/src/json2mongo.ts
@@ -13,6 +13,9 @@ export const json2mongo = (obj: any) => {
       case '$type':
         return new mongo.Binary(obj.$binary, obj.$type);
       case '$date':
+        if (!val) {
+          return new Date();
+        }
         return new Date(val);
       case '$decimal128':
         return new mongo.Decimal128(Buffer.from(val));

--- a/src/json2mongo.ts
+++ b/src/json2mongo.ts
@@ -18,7 +18,7 @@ export const json2mongo = (obj: any) => {
         }
         return new Date(val);
       case '$decimal128':
-        return new mongo.Decimal128(Buffer.from(val));
+        return new mongo.Decimal128(Buffer  .from(val));
       case '$timestamp':
         return new mongo.Timestamp(val.t, val.i);
       case '$regex':


### PR DESCRIPTION
We are using this dependency on our project, but we faced with a problem. When we need a current date on seeder, it was impossible because it read a JSON instead a BSON. For resolve this problem we needed change the code when date is empty to put current date. I guess it is better than the approach used today.