### PR TITLE
Return promise that resolves after all files seeded in seedAll()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export const seedAll = async (
     const seedsFolder = resolve(dataFolder);
     const seedFiles = getJsonFiles(seedsFolder);
     await connectToDB(mongoUri);
-    await seedFiles.forEach(seedAFile);
+    await Promise.all(seedFiles.map(seedAFile))
     return true;
   } catch (e) {
     console.log(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export const seedAll = async (
     const seedsFolder = resolve(dataFolder);
     const seedFiles = getJsonFiles(seedsFolder);
     await connectToDB(mongoUri);
-    await Promise.all(seedFiles.map(seedAFile))
+    await Promise.all(seedFiles.map(seedAFile));
     return true;
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
In the existing version, the line:
```ts
await seedFiles.forEach(seedAFile);
```
returns immediately since `forEach` just runs the `seedAFile` function for each file but doesn't wait for their promises to resolve. So the entire task would resolve early before actually seeding everything. 

I have replaced this with `Promise.all` which will resolve after all files have been seeded.